### PR TITLE
Add --no-track to cargo invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,5 +190,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@freundTech](https://github.com/freundTech/)
 * [@pavelzw](https://github.com/pavelzw/)
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,7 +2,7 @@ cargo-bundle-licenses ^
     --format yaml ^
     --output THIRDPARTY_LICENSES.yaml || goto :error
 
-cargo install --locked --root "%PREFIX%" --path .\crates\typst-cli || goto :error
+cargo install --no-track --locked --root "%PREFIX%" --path .\crates\typst-cli || goto :error
 
 goto :EOF
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,6 +4,6 @@ cargo-bundle-licenses \
     --format yaml \
     --output THIRDPARTY_LICENSES.yaml
 
-cargo install --locked --root "$PREFIX" --path crates/typst-cli
+cargo install --no-track --locked --root "$PREFIX" --path crates/typst-cli
 
 "$STRIP" "$PREFIX/bin/typst"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f1b7baba3c6f6f37dee6d05c9ab53d2ba5cd879a57b6e726dedf9bc51811e132
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This prevents cargo from adding .crates.toml and .crates2.json files in the install root.
