### PR TITLE
Fix typo in windows activation script

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a4a8f5275a642ec5ee79ef8c29c77d98a317cd2ae0bae46c3a1eef1167cd1725
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipe/scripts/activate.bat
+++ b/recipe/scripts/activate.bat
@@ -1,3 +1,3 @@
 @echo off
 set "TYPST_PACKAGE_PATH_CONDA_BACKUP=%TYPST_PACKAGE_PATH%"
-set "TYPST_PACKAGE_PATH="%CONDA_PREFIX%\Library\share\typst\packages"
+set "TYPST_PACKAGE_PATH=%CONDA_PREFIX%\Library\share\typst\packages"


### PR DESCRIPTION
Surprisingly this doesn't error at runtime, but just prepends a double quote to the env variable value...

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
